### PR TITLE
Fix Generated Renderer

### DIFF
--- a/processor/src/main/java/com/bael/dads/processor/ext/NameExt.kt
+++ b/processor/src/main/java/com/bael/dads/processor/ext/NameExt.kt
@@ -7,5 +7,8 @@ import javax.lang.model.element.Name
  */
 
 fun Name.toGetter(): String {
-    return "get${toString().capitalize()}()"
+    return toString().let { name ->
+        if (name.take(2) == "is") "$name()"
+        else "get${name.capitalize()}()"
+    }
 }


### PR DESCRIPTION
Discard `get`-prefix if var started with `is`